### PR TITLE
fix: added context to DateTime types

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -67,7 +67,7 @@
         "courseOverGround": "https://smartdatamodels.org/dataModel.MarineTransport/courseOverGround",
         "createdAt": {
             "@id": "ngsi-ld:createdAt",
-            "@type": "DateTime"
+            "@type": "ngsi-ld:DateTime"
         },
         "crewArrival": "https://smartdatamodels.org/dataModel.MarineTransport/crewArrival",
         "crewDeparture": "https://smartdatamodels.org/dataModel.MarineTransport/crewDeparture",
@@ -128,7 +128,7 @@
         "mmsi": "https://smartdatamodels.org/dataModel.MarineTransport/mmsi",
         "modifiedAt": {
             "@id": "ngsi-ld:modifiedAt",
-            "@type": "DateTime"
+            "@type": "ngsi-ld:DateTime"
         },
         "mooringLines": "https://smartdatamodels.org/dataModel.MarineTransport/mooringLines",
         "mrn": "https://smartdatamodels.org/dataModel.MarineTransport/mrn",
@@ -138,7 +138,7 @@
         "ngsi-ld": "https://uri.etsi.org/ngsi-ld/",
         "observedAt": {
             "@id": "ngsi-ld:observedAt",
-            "@type": "DateTime"
+            "@type": "ngsi-ld:DateTime"
         },
         "operationType": "https://smartdatamodels.org/dataModel.MarineTransport/operationType",
         "originTransportType": "https://smartdatamodels.org/dataModel.MarineTransport/originTransportType",


### PR DESCRIPTION
Not an expert in contexts but this context syntax might not be correct. I am trying to reference this context and getting

```
Caused by: com.fasterxml.jackson.databind.JsonMappingException: There was a problem encountered loading a remote context [code=LOADING_REMOTE_CONTEXT_FAILED].
    at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._wrapAsIOE(DefaultSerializerProvider.java:509)
    at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:482)
    at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
    at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4568)
    at com.fasterxml.jackson.databind.ObjectMapper.writeValue(ObjectMapper.java:3780)
    at io.micronaut.jackson.databind.JacksonDatabindMapper.writeValue(JacksonDatabindMapper.java:124)
    at io.micronaut.jackson.databind.JacksonDatabindMapper.writeValue(JacksonDatabindMapper.java:129)
    at io.micronaut.json.codec.MapperMediaTypeCodec.encode(MapperMediaTypeCodec.java:219)
    ... 166 common frames omitted
```

When I tried to check the syntax, I notice there might be an error.

https://json-ld.org/playground/#startTab=tab-expanded&json-ld=https%3A%2F%2Fraw.githubusercontent.com%2Fsmart-data-models%2FdataModel.MarineTransport%2Frefs%2Fheads%2Fmaster%2Fcontext.jsonld

I updated the type DateTime to be aligned with the syntax, and personal tests with the library was successful.

https://json-ld.org/playground/#startTab=tab-expanded&json-ld=https%3A%2F%2Fraw.githubusercontent.com%2Falperbasak%2FdataModel.MarineTransport%2Frefs%2Fheads%2Fmaster%2Fcontext.jsonld 

